### PR TITLE
remove duplicate "}from" in named import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Similar to Python, we have named imports:
 ```javascript
 import { 
   sumTwo as addTwoNumbers, 
-  sumThree as sumThreeNumbers} from
+  sumThree as sumThreeNumbers
 } from 'math/addition'
 ```
 


### PR DESCRIPTION
there was a double "} from" in the named import example
