### PR TITLE
Adjust multiline template string example

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,11 +232,9 @@ var text = [
 **Template Literals** will preserve new lines for us without having to explicitly place them in:
 
 ```javascript
-let text = (
-  `cat
-  dog
-  nickelodeon`
-)
+let text = `cat
+dog
+nickelodeon`
 ```
 
 **Template Literals** can accept expressions, as well:


### PR DESCRIPTION
Remove indentation from template string so it is equivalent to the other snippets, i.e., `"cat\ndog\nnickelodeon"` instead of `"cat\n  dog\n nickelodeon"`.
