### PR TITLE
Added missing argument to export example

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ function sumTwo(a, b) {
     return a + b;
 }
 
-function sumThree(a, b) {
+function sumThree(a, b, c) {
     return a + b + c;
 }
 
@@ -328,7 +328,7 @@ export function sumTwo(a, b) {
     return a + b;
 }
 
-export function sumThree(a, b) {
+export function sumThree(a, b, c) {
     return a + b + c;
 }
 ```
@@ -340,7 +340,7 @@ function sumTwo(a, b) {
     return a + b;
 }
 
-function sumThree(a, b) {
+function sumThree(a, b, c) {
     return a + b + c;
 }
 


### PR DESCRIPTION
The sumThree function uses `a`, `b`, `c` but only takes `a`, `b`.
