### PR TITLE
Modify var vs. let formatting to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ However, observe what happens when we replace **var** using **let**:
 let snack = 'Meow Mix';
 
 function getFood(food) {
-
     if (food) {
         let snack = 'Friskies';
         return snack;


### PR DESCRIPTION
See title. No reason why they should be formatted differently.
