### PR TITLE
Fix Template Literals Comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,10 +231,9 @@ var text = [
 **Template Literals** will preserve new lines for us without having to explicitly place them in:
 
 ```javascript
-let text = ( `
-  cat
-  dog
-  nickelodeon`
+let text = ( `cat
+dog
+nickelodeon`
 )
 ```
 


### PR DESCRIPTION
The string comparison in the `Template Literals` section was incorrect.

It was comparing
-  es5
  
  ``` js
  var text = (
     'cat\n' +
     'dog\n' +
     'nickelodeon'
  )
  ```
  
  and
  
  ``` javascript
  var text = [
     'cat',
     'dog',
     'nickelodeon'
  ].join('\n')
  ```

to
- es6
  
  ``` javascript
  let text = ( `
     cat
     dog
     nickelodeon`
  )
  ```

However, both of the es5 examples result in a string equivalent to:
`'cat\ndog\nnickelodeon'`

Whereas the previous es6 example results in:
`'\n  cat\n  dog\n  nickelodeon'`

After this change the es6 example is now the same as the es5 examples:
`'cat\ndog\nnickelodeon'`
