### PR TITLE
Pass scope to map function

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,9 @@ function Person(name) {
 }
 
 Person.prototype.prefixName = function (arr) {
-    var that = this; // Store the context of this
     return arr.map(function (character) {
         return that.name + character;
-    });
+    }, this);
 };
 ```
 


### PR DESCRIPTION
While using map we can pass the scope to the map function, or use a native function that you can't pass the scope.

And yes, I read the title for the example. If this PR is approved, that line must be updated.
"One common solution to this problem is to store the context of this using a variable:"
