### PR TITLE
Comment to named parameters is placed outside of the function scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,9 +554,8 @@ to a function:
 ```javascript
 function initializeCanvas(
     { height=600, width=400, lineStroke='black'}) {
-        // ...
+        // Use variables height, width, lineStroke here
     }
-    // Use variables height, width, lineStroke here
 ```
 
 If we want to make the entire value optional, we can do so by destructuring an


### PR DESCRIPTION
There was a small error in where the comment telling the user where to use the named variables was placed outside of the function.
