### PR TITLE
docs: Fix simple typo, asynchronousity -> asynchronicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,7 +1034,7 @@ will allow us to push our generator forward and evaluate a new expression. While
 contrived, we can utilize Generators to write asynchronous code in a synchronous manner:
 
 ```javascript
-// Hiding asynchronousity with Generators
+// Hiding asynchronicity with Generators
 
 function request(url) {
     getJSON(url, function(response) {

--- a/README_zhCn.md
+++ b/README_zhCn.md
@@ -965,7 +965,7 @@ var generator = sillyGenerator();
 我们能利用Generators来像书写同步代码一样书写异步代码。
 
 ```javascript
-// Hiding asynchronousity with Generators
+// Hiding asynchronicity with Generators
 
 function request(url) {
     getJSON(url, function(response) {


### PR DESCRIPTION
There is a small typo in README.md, README_zhCn.md.

Should read `asynchronicity` rather than `asynchronousity`.

